### PR TITLE
Fix a display bug when adding apps to a folder

### DIFF
--- a/appfolders-manager@maestroschan.fr/appfolderDialog.js
+++ b/appfolders-manager@maestroschan.fr/appfolderDialog.js
@@ -252,7 +252,7 @@ var AppfolderDialog = class AppfolderDialog {
 	}
 
 	_removeChar(folderId, char) {
-		tmp0 = folderId.split(char);
+		let tmp0 = folderId.split(char);
 		folderId = "";
 		for(var i = 0; i < tmp0.length; i++) {
 			folderId += tmp0[i];

--- a/appfolders-manager@maestroschan.fr/dragAndDrop.js
+++ b/appfolders-manager@maestroschan.fr/dragAndDrop.js
@@ -541,6 +541,10 @@ class FolderArea extends DroppableArea {
 		if ((source instanceof AppDisplay.AppIcon) &&
 		                            !Extension.isInFolder(source.id, this.id)) {
 			Extension.addToFolder(source, this.id);
+			//redisplay
+			OVERLAY_MANAGER.computeFolderOverlayActors();
+			OVERLAY_MANAGER.updateState(false);
+			Main.overview.viewSelector.appDisplay._views[1].view._redisplay();
 			Main.overview.endItemDrag(this);
 			return true;
 		}

--- a/appfolders-manager@maestroschan.fr/extension.js
+++ b/appfolders-manager@maestroschan.fr/extension.js
@@ -263,6 +263,7 @@ function removeFromFolder (app_id, folder_id) {
 		content.push(app_id);
 		folder_schema.set_strv('excluded-apps', content);
 	}
+	repaintFolder();
 	return true;
 }
 
@@ -366,13 +367,17 @@ function addToFolder (app_source, folder_id) {
 	folder_schema.set_strv('apps', content); //XXX verbose errors
 	
 	//update icons in the ugliest possible way
-	let icons = Main.overview.viewSelector.appDisplay._views[1].view.folderIcons;
-	for (let i=0; i<icons.length; i++) {
-		let size = icons[i].icon._iconBin.width;
-		icons[i].icon.icon = icons[i]._createIcon(size);
-		icons[i].icon._iconBin.child = icons[i].icon.icon;
-	}
+	repaintFolder();
 	return true;
+}
+
+//------------------------------------------------------------------------------
+
+function repaintFolder(){
+	let icons = Main.overview.viewSelector.appDisplay._views[1].view.folderIcons; 
+	for (let i=0; i<icons.length; i++) {
+		icons[i].icon._createIconTexture(icons[i].icon.iconSize);
+	}
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
fix https://github.com/maoschanz/appfolders-manager-gnome-extension/issues/82
Add several steps about recompute and redisplay after adding an app into a folder, the app icon may not become bigger and bigger. 
