### PR TITLE
fix a folder display bug when adding apps to folder

### DIFF
--- a/appfolders-manager@maestroschan.fr/appfolderDialog.js
+++ b/appfolders-manager@maestroschan.fr/appfolderDialog.js
@@ -252,7 +252,7 @@ var AppfolderDialog = class AppfolderDialog {
 	}
 
 	_removeChar(folderId, char) {
-		tmp0 = folderId.split(char);
+		let tmp0 = folderId.split(char);
 		folderId = "";
 		for(var i = 0; i < tmp0.length; i++) {
 			folderId += tmp0[i];

--- a/appfolders-manager@maestroschan.fr/extension.js
+++ b/appfolders-manager@maestroschan.fr/extension.js
@@ -263,6 +263,7 @@ function removeFromFolder (app_id, folder_id) {
 		content.push(app_id);
 		folder_schema.set_strv('excluded-apps', content);
 	}
+	repaintFolder();
 	return true;
 }
 
@@ -366,13 +367,17 @@ function addToFolder (app_source, folder_id) {
 	folder_schema.set_strv('apps', content); //XXX verbose errors
 	
 	//update icons in the ugliest possible way
-	let icons = Main.overview.viewSelector.appDisplay._views[1].view.folderIcons;
-	for (let i=0; i<icons.length; i++) {
-		let size = icons[i].icon._iconBin.width;
-		icons[i].icon.icon = icons[i]._createIcon(size);
-		icons[i].icon._iconBin.child = icons[i].icon.icon;
-	}
+	repaintFolder();
 	return true;
+}
+
+//------------------------------------------------------------------------------
+
+function repaintFolder(){
+	let icons = Main.overview.viewSelector.appDisplay._views[1].view.folderIcons; 
+	for (let i=0; i<icons.length; i++) {
+		icons[i].icon._createIconTexture(icons[i].icon.iconSize);
+	}
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
use `icons[i].icon._createIconTexture(icons[i].icon.iconSize)` to repaint the folderIcon could avoid the appIcon become bigger and bigger when adding to a folder.
that's probably because `let size = icons[i].icon._iconBin.width;` can not get the correct value under system display scale more than 100%. 
I've test this change on Fedora30, this may help to fix #82 as well, thanks!
