### PR TITLE
fix bug: add to&remove from freezes the application grid

### DIFF
--- a/appfolders-manager@maestroschan.fr/extension.js
+++ b/appfolders-manager@maestroschan.fr/extension.js
@@ -99,7 +99,6 @@ function injectionInAppsMenus() {
 					mainAppView._currentPopup.popdown();
 				}
 				createNewFolder(this._source);
-				mainAppView._redisplay();
 				Mainloop.source_remove(a);
 			});
 		});
@@ -128,7 +127,6 @@ function injectionInAppsMenus() {
 							mainAppView._currentPopup.popdown();
 						}
 						addToFolder(this._source, _folder);
-						mainAppView._redisplay();
 						Mainloop.source_remove(a);
 					});
 				});
@@ -167,7 +165,6 @@ function injectionInAppsMenus() {
 							mainAppView._currentPopup.popdown();
 						}
 						removeFromFolder(appId, _folder);
-						mainAppView._redisplay();
 						Mainloop.source_remove(a);
 					});
 				});


### PR DESCRIPTION
fix #72, "add to" can also cause this problem.
This is the solution I got from trying, but I still don't know how it works, sigh~ What do you think?
Btw, I have test to delete all `Main.overview.viewSelector.appDisplay._views[1].view._redisplay();`, it still seems to work. 